### PR TITLE
Improve Monit polling behavior during monitored process restart

### DIFF
--- a/ralf.root/usr/share/clearwater/bin/poll_ralf.sh
+++ b/ralf.root/usr/share/clearwater/bin/poll_ralf.sh
@@ -37,4 +37,16 @@
 . /etc/clearwater/config
 http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 /usr/share/clearwater/bin/poll-http $http_ip:10888
-exit $?
+rc=$?
+
+# If the ralf process is not stable, we ignore a non-zero return code and
+# return zero.
+if [ $rc != 0 ]; then
+  /usr/share/clearwater/infrastructure/monit_stability/ralf-stability check
+  if [ $? != 0 ]; then
+    echo "return code $rc ignored" >&2
+    rc=0
+  fi
+fi
+
+exit $rc

--- a/ralf.root/usr/share/clearwater/infrastructure/monit_stability/ralf-stability
+++ b/ralf.root/usr/share/clearwater/infrastructure/monit_stability/ralf-stability
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# @file ralf-stability
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+# Used for monitoring the stability of the ralf process.
+
+PROCESS_NAME="ralf"
+GRACE_PERIOD=20
+
+method=$1
+
+/usr/share/clearwater/bin/process-stability $method $PROCESS_NAME $GRACE_PERIOD
+exit $?

--- a/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf.monit
+++ b/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf.monit
@@ -42,16 +42,16 @@ cat > /etc/monit/conf.d/ralf.monit <<EOF
 
 # Monitor the service's PID file and memory use.
 check process ralf_process with pidfile /var/run/ralf/ralf.pid
-  group ralf 
+  group ralf
 
   # The start, stop and restart commands are linked to alarms
-  start program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf start'"
+  start program = "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/ralf-stability reset; /usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf start'"
   stop program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf stop'"
-  restart program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf restart'"
+  restart program = "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/ralf-stability reset; /usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf restart'"
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection.
-  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf abort'"
+  if memory > 40% then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/ralf-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf abort'"
 
 # Clear any alarms if the process has been running long enough.
 check program ralf_uptime with path /usr/share/clearwater/infrastructure/scripts/check-ralf-uptime
@@ -67,7 +67,7 @@ check program poll_ralf with path "/usr/share/clearwater/bin/poll_ralf.sh"
   depends on ralf_process
 
   # Aborting generates a core file and triggers diagnostic collection.
-  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf abort'"
+  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/ralf-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf abort'"
 EOF
 chmod 0644 /etc/monit/conf.d/ralf.monit
 

--- a/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf.monit
+++ b/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf.monit
@@ -51,7 +51,7 @@ check process ralf_process with pidfile /var/run/ralf/ralf.pid
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection.
-  if memory > 40% then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/ralf-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf abort'"
+  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/ralf-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf abort'"
 
 # Clear any alarms if the process has been running long enough.
 check program ralf_uptime with path /usr/share/clearwater/infrastructure/scripts/check-ralf-uptime


### PR DESCRIPTION
This is a process-specific fix for [#59](https://github.com/ClearwaterCore/clearwater-infrastructure/pull/59).